### PR TITLE
Add per-user memory support using hashed user IDs and display names

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,18 +1,19 @@
----
-outline: deep
----
-
 # Privacy Policy
 
-*Last updated: July 13th, 2025*
+*Last updated: July 14th, 2025*
 
 This Privacy Policy describes how **Al**, the conversational AI Discord bot (“we”, “us”, or “our”), handles your data when you interact with the bot on Discord.
 
 ## 1. Data Collection
 
 * **Al does not collect personal data** beyond what is necessary to function as a Discord bot.
-* When you interact with Al, your messages (and the bot’s replies) may be stored locally in a file (`memory.jsonl`) on the machine hosting the bot.
-* This data is used solely for maintaining conversational context and improving Al’s responses.
+* When you interact with Al:
+
+  * Your message content and Al’s replies may be stored locally in a file (e.g. `memory.jsonl`).
+  * A **hashed version of your Discord user ID** may be stored to allow Al to maintain separate memories for different users without identifying you directly.
+  * Your **display name** may be stored to personalize replies.
+
+This data is used solely for maintaining conversational context and enhancing the user experience.
 
 ## 2. Local Storage Only
 
@@ -24,24 +25,26 @@ This Privacy Policy describes how **Al**, the conversational AI Discord bot (“
 
 * Al uses the Discord API to read and respond to messages.
 * Al only accesses:
+
   * Your message content (if you mention the bot or reply to it),
-  * Your username and user ID (as part of the message metadata, this data is not stored),
+  * Your username, user ID (hashed if stored), and display name,
   * The server and channel the message was sent in.
 * Al does not read private DMs unless explicitly invited into them.
 
 ## 4. Data Retention
 
-* Conversation logs are stored in a file (`memory.jsonl`) and persist until deleted manually by the bot host.
-* If you are not the host of the bot, you should contact the server owner or bot operator regarding data stored locally.
+* Conversation logs are stored in a file (`memory.jsonl`) and persist until manually deleted by the bot host.
+* If you are not the host of the bot, you should contact the server owner or bot operator regarding locally stored data.
 
 ## 5. Your Rights
 
 * Since Al stores data locally, the bot operator is responsible for managing that data.
-* If you’d like your past messages removed from Al’s memory, contact the server owner or whoever runs the instance of the bot.
+* If you’d like your stored messages or data removed, contact the server owner or whoever runs the instance of the bot.
 
 ## 6. Security
 
 * Data is stored in plaintext and is not encrypted.
+* Hashed user IDs are used to reduce the risk of identifying users.
 * It is the responsibility of the bot host to secure the server or machine where Al is running.
 
 ## 7. Changes to this Policy
@@ -51,4 +54,4 @@ This Privacy Policy describes how **Al**, the conversational AI Discord bot (“
 
 ## 8. Contact
 
-For questions about this Privacy Policy, please contact the bot developer or maintainer listed on the [GitHub repository](https://github.com/myferr/al) or contacting via [e-mail](mailto:contactme.myfer@protonmail.com)
+For questions about this Privacy Policy, please contact the bot developer or maintainer listed on the [GitHub repository](https://github.com/myferr/al) or via [e-mail](mailto:contactme.myfer@protonmail.com)

--- a/src/memory.py
+++ b/src/memory.py
@@ -1,19 +1,32 @@
 import os
 import json
+import hashlib
 from settings import MEMORY_FILE
 
-def load_memory():
+def scramble_user_id(user_id: str) -> str:
+    return hashlib.sha256(user_id.encode()).hexdigest()
+
+def load_memory(user_id: str):
+    user_hash = scramble_user_id(user_id)
     messages = []
     if os.path.exists(MEMORY_FILE):
         with open(MEMORY_FILE, 'r', encoding='utf-8') as f:
             for line in f:
                 try:
-                    messages.append(json.loads(line))
+                    entry = json.loads(line)
+                    if entry.get("user_hash") == user_hash:
+                        messages.append({"role": entry["role"], "content": entry["content"]})
                 except json.JSONDecodeError:
                     print(f"Invalid JSON: {line.strip()}")
     return messages
 
-def save_message(role, content):
-    entry = {"role": role, "content": content}
+def save_message(user_id: str, role: str, content: str, display_name: str):
+    user_hash = scramble_user_id(user_id)
+    entry = {
+        "user_hash": user_hash,
+        "role": role,
+        "content": content,
+        "display_name": display_name
+    }
     with open(MEMORY_FILE, 'a', encoding='utf-8') as f:
         f.write(json.dumps(entry) + '\n')


### PR DESCRIPTION
This PR improves the conversational accuracy of Al by introducing **per-user context tracking**, while maintaining user privacy.

#### Key Changes:

* Hashed Discord user IDs (e.g., SHA256) are now stored to distinguish between users.
* Conversation memory is now user-specific, enabling better context in multi-user environments.
* Display names are stored alongside hashed IDs to allow for personalized responses.
* No raw user IDs are stored—only irreversible hashes.
* Privacy Policy updated to reflect these changes.

Previously, Al used a shared memory file for all users, leading to confusion when multiple people chatted at once. Now, Al can track distinct conversations safely, with no compromise to user identity.